### PR TITLE
Fix: Remove transição lenta da câmera de pré-visualização

### DIFF
--- a/shared/utils.lua
+++ b/shared/utils.lua
@@ -90,7 +90,7 @@ function utils.destroyPreviewCam(vehicle, enterVehicle)
             DoScreenFadeIn(500)
         end
 
-        RenderScriptCams(false, true, 1500, false, false)
+        RenderScriptCams(false, false, 0, false, false)
         DestroyCam(utils.previewCam, true)
         utils.previewCam = nil
     end


### PR DESCRIPTION
Altera a transição de 1500ms para 0ms, evitando o efeito de "voô" ao destruir a câmera.   
Vídeo do fix: https://streamable.com/o4o9kk